### PR TITLE
Disable threading support in uwsgi to improve workload stability

### DIFF
--- a/django-workload/uwsgi.ini
+++ b/django-workload/uwsgi.ini
@@ -19,7 +19,6 @@ master = True
 auto-procname = True
 die-on-term = True
 
-enable-threads = True
 single-interpreter = True
 py-call-osafterfork = True
 optimize = 2


### PR DESCRIPTION
With the "enable-threads" option on, I could experience high CPU idle time, up to 95%. The idle time was also inconsistent after restarting uwsgi.

Removing "enable-threads" from uwsgi.ini eliminates this behavior and improves workload stability, allowing for a constant CPU utilization.