### PR TITLE
Disable logging and fix docker-statsd config

### DIFF
--- a/django-workload/README.md
+++ b/django-workload/README.md
@@ -49,6 +49,15 @@ to see what went wrong.
 
 ## Debug
 
+### uWSGI Logging
+Logging for uWSGI is turned off by default for benchmarking purposes. In order
+to turn it back on, comment out the `disable-logging` parameter in uwsgi.ini,
+like this:
+```
+#disable-logging = True
+```
+
+### Django debugging
 If you get HTTP response codes different than 200, change the DEBUG parameter
 in cluster_settings.py:
 

--- a/django-workload/uwsgi.ini
+++ b/django-workload/uwsgi.ini
@@ -31,3 +31,4 @@ thunder-lock = True
 
 stats = 127.0.0.1:9191
 logger = file:django-uwsgi.log
+disable-logging = True

--- a/services/cassandra/README.md
+++ b/services/cassandra/README.md
@@ -95,7 +95,12 @@ following options in `/etc/cassandra/jvm.options`:
 -XX:+AlwaysPreTouch
 -XX:+UnlockDiagnosticVMOptions
 -XX:ParGCCardsPerStrideChunk=4096
+```
 
+## Logging
+If needed, logging can be enabled for Cassandra by adding the following flags
+to `/etc/cassandra/jvm.options`:
+```
 # Logging
 -XX:+PrintGCDetails
 -XX:+PrintGCDateStamps

--- a/services/memcached/README.md
+++ b/services/memcached/README.md
@@ -17,3 +17,10 @@ then the ./run-memcached script to run a new, separate server, as root (the
 daemon switches to `memcache` user after starting)
 
     sudo ./run-memcached
+
+## Logging
+If needed, logging can be enabled for Memcached by adding the `-vv` switch in
+the run-memcached script:
+```
+/usr/bin/memcached -vv -u $USER -m $MEMORY -l $LISTEN -p $PORT
+```

--- a/services/memcached/run-memcached
+++ b/services/memcached/run-memcached
@@ -15,4 +15,4 @@ PORT="${PORT:-11811}"
 # User to run under
 USER="${USER:-memcache}"
 
-/usr/bin/memcached -vv -u $USER -m $MEMORY -l $LISTEN -p $PORT
+/usr/bin/memcached -u $USER -m $MEMORY -l $LISTEN -p $PORT

--- a/services/monitoring/README.md
+++ b/services/monitoring/README.md
@@ -18,3 +18,46 @@ at:
     https://github.com/hopsoft/docker-graphite-statsd
 
 Timeseries data can then be directed to UDP port 8125.
+
+## Mandatory config
+The default config of the hopsoft/graphite-statsd docker container will likely
+cause your storage space to run out because of the amount of data being logged
+into statsd by the Django Workload. In order to solve this, please perform the
+steps below after starting the container. All commands should be run as root.
+
+Obtain a shell in the container:
+```
+sudo docker exec -it graphite bash
+cd opt/graphite/conf/
+```
+
+Add the following line to `blacklist.conf`:
+```
+^stats[^.]*\.benchmarkoutput\.
+```
+
+Edit the `carbon.conf` file to enable whitelisting. Search for the line
+containing `USE_WHITELIST`, uncomment it and set it to True:
+```
+USE_WHITELIST = True
+```
+
+Edit the retention policy in `storage-schemas.conf`:
+```
+[default_1min_for_1day]
+pattern = .*
+retentions = 10s:2h,1min:2d,10min:14d
+```
+
+Exit the docker container and restart it for the configurations to take effect:
+```
+exit
+docker stop graphite
+docker start graphite
+```
+
+Should the disk space fill up again, you can simply delete graphite’s database:
+```
+docker exec -it graphite bash
+rm –rf /opt/graphite/storage/whisper/*
+```


### PR DESCRIPTION
Disable logging for Cassandra, Memcached and uWSGI, while leaving README instructions on how to turn it back on. A fix is also provided for the docker-statsd container in order to prevent it from filling up disk space.