### PR TITLE
Fix bug in Siege runner script

### DIFF
--- a/client/run-siege
+++ b/client/run-siege
@@ -122,7 +122,7 @@ def validate_output(siege_file):
 
 
 def run_siege(options):
-    cmd = "siege -v -c " + str(WORKERS) + "-b -t " + DURATION
+    cmd = "siege -v -c " + str(WORKERS) + " -b -t " + DURATION
     cmd = cmd + " -f " + SOURCE + " --log=" + LOG + " &>> "
     iterations = 7
     url_dict, url_target = parse_urls(URLS_TEMPLATE_FILE)


### PR DESCRIPTION
Fix the Siege runner command to correctly pass the "-b" command, which puts Siege in benchmarking mode.