### PR TITLE
Add option to enable/disable statsd profiling

### DIFF
--- a/django-workload/cluster_settings_template.py
+++ b/django-workload/cluster_settings_template.py
@@ -23,3 +23,11 @@ STATSD_PORT = 8125
 
 # Memcached connection
 CACHES['default']['LOCATION'] = '127.0.0.1:11811'
+
+# Enable/disable profiling
+PROFILING = False
+
+if not PROFILING:
+    MIDDLEWARE.remove('django_workload.middleware.memory_cpu_stats_middleware')
+    MIDDLEWARE.remove('django_workload.middleware.GraphiteRequestTimingMiddleware')
+    MIDDLEWARE.remove('django_workload.middleware.GraphiteMiddleware')

--- a/django-workload/django_workload/settings.py
+++ b/django-workload/django_workload/settings.py
@@ -21,6 +21,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# Enable/Disable profiling
+PROFILING = True
 
 # Application definition
 

--- a/django-workload/django_workload/views.py
+++ b/django-workload/django_workload/views.py
@@ -13,6 +13,7 @@ from django.http import HttpResponse
 from django.views.decorators.cache import cache_page
 from django.views.decorators.http import require_http_methods
 from django_statsd.clients import statsd
+from django.conf import settings
 
 from cassandra.cqlengine.query import BatchQuery
 
@@ -153,10 +154,12 @@ def seen(request):
 
     with statsd.pipeline() as pipe, BatchQuery() as b:
         for bundleid in random.sample(bundleids, random.randrange(3)):
-            pipe.incr('workloadoutput.bundle.{}.seen'.format(bundleid.hex))
+            if settings.PROFILING:
+                pipe.incr('workloadoutput.bundle.{}.seen'.format(bundleid.hex))
             for entryid in random.sample(entryids, random.randrange(5)):
-                pipe.incr('workloadoutput.bundle.{}.{}.seen'.format(
-                    bundleid.hex, entryid.hex))
+                if settings.PROFILING:
+                    pipe.incr('workloadoutput.bundle.{}.{}.seen'.format(
+                        bundleid.hex, entryid.hex))
                 BundleSeenModel(
                     userid=request.user.id, bundleid=bundleid, entryid=entryid
                 ).save()


### PR DESCRIPTION
Add option to cluster_settings_template.py to enable/disable statsd profiling. Profiling is done for each request and this decreases the throughput by almost 6x and causes high kernel time for kernels newer than 4.4 (Ubuntu 16.04 now comes with Linux kernel 4.8). Disabling profiling eliminates the high kernel time.