### PR TITLE
Implement sample-based profiling

### DIFF
--- a/django-workload/cluster_settings_template.py
+++ b/django-workload/cluster_settings_template.py
@@ -24,6 +24,9 @@ STATSD_PORT = 8125
 # Memcached connection
 CACHES['default']['LOCATION'] = '127.0.0.1:11811'
 
+# Sample rate for profiling
+SAMPLE_RATE = 1000
+
 # Enable/disable profiling
 PROFILING = False
 

--- a/django-workload/django_workload/patches.py
+++ b/django-workload/django_workload/patches.py
@@ -107,8 +107,6 @@ if settings.PROFILING:
                 global MEMCACHED_COUNT
 
                 MEMCACHED_COUNT += 1
-                with open("/tmp/sampling.out", "a") as f:
-                    f.write(str(MEMCACHED_COUNT) + " " + str(settings.SAMPLE_RATE) + "\n")
                 if MEMCACHED_COUNT >= settings.SAMPLE_RATE:
                     MEMCACHED_COUNT = 0
                     key = 'memcached.{}.{}'.format(get_view_name(), orig.__name__)

--- a/django-workload/django_workload/settings.py
+++ b/django-workload/django_workload/settings.py
@@ -21,6 +21,9 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# Sample rate for profiling
+SAMPLE_RATE = 1000
+
 # Enable/Disable profiling
 PROFILING = True
 


### PR DESCRIPTION
Implemented sample-based profiling every 1000 requests for the workload, to simulate a real-world usage scenario. In the previous configuration, path length would increase by 6x (vs no profiling) because of the profiling middleware, causing low req/s numbers.