### PR TITLE
Add Python work to each view to increase CPU utilization

### DIFF
--- a/django-workload/django_workload/bundle_tray.py
+++ b/django-workload/django_workload/bundle_tray.py
@@ -81,7 +81,8 @@ class BundleTray(object):
                     break
             if not exists:
                 conf.final_items.append(item)
-            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL opcodes
+            # boost LOAD_ATTR, CALL_FUNCTION, POP_JUMP_IF_FALSE, LOAD_FAST
+            # and LOAD_GLOBAL opcodes
             conf.loops = 0
             load_mult = conf.load_mult
             while conf.loops < load_mult:

--- a/django-workload/django_workload/bundle_tray.py
+++ b/django-workload/django_workload/bundle_tray.py
@@ -1,0 +1,118 @@
+from .models import (
+    BundleEntryModel,
+    FeedEntryModel,
+    UserModel,
+)
+
+
+INC_FACTOR = 1
+
+
+class BundleTray(object):
+    def __init__(self, request):
+        self.request = request
+
+    def get_bundle(self):
+        bundles = list(
+            BundleEntryModel.objects
+            .filter(userid__in=self.request.user.following).limit(10))
+        # only one bundle per user
+        userids = {}
+        feedentryids = []
+        for bundle in bundles:
+            if bundle.userid in userids:
+                continue
+            userids[bundle.userid] = bundle.id
+            feedentryids += bundle.entry_ids
+        first_bundleids = set(userids.values())
+        # Fetch user information
+        userinfo = {}
+        for user in UserModel.objects.filter(id__in=list(userids)):
+            userinfo[user.id] = user.json_data
+        # fetch entry information
+        feedentryinfo = {}
+        for feedentry in FeedEntryModel.objects.filter(id__in=list(feedentryids)):
+            feedentryinfo[feedentry.id] = {
+                'pk': str(feedentry.id),
+                'comment_count': feedentry.comment_count,
+                'published': feedentry.published.timestamp(),
+            }
+
+        result = {'bundle': [
+            {
+                'pk': str(b.id),
+                'comment_count': b.comment_count,
+                'published': b.published.timestamp(),
+                'user': userinfo[b.userid],
+                'items': [
+                    feedentryinfo[f]
+                    for f in bundle.entry_ids if f in feedentryinfo]
+            }
+            for b in bundles if b.id in first_bundleids
+        ]}
+        return result
+
+    def get_inc_factor(self):
+        global INC_FACTOR
+        return int((INC_FACTOR + 1) / 2)
+
+    def post_process(self, res):
+        bundle_list = res['bundle']
+        conf = BundleConfig()
+
+        # duplicate the data
+        for i in range(conf.get_mult_factor()):
+            conf.list_extend(bundle_list)
+
+        sorted_list = sorted(conf.get_list(),
+                             key=lambda x: x['published'],
+                             reverse=True)
+        conf.final_items = []
+
+        for item in sorted_list:
+            conf.comm_total = conf.comm_total + item['comment_count']
+            for sub in item['items']:
+                conf.comm_total = conf.comm_total + sub['comment_count']
+            # un-duplicate the data
+            exists = False
+            for final_item in conf.final_items:
+                if final_item['published'] == item['published']:
+                    exists = True
+                    break
+            if not exists:
+                conf.final_items.append(item)
+            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL opcodes
+            conf.loops = 0
+            load_mult = conf.load_mult
+            while conf.loops < load_mult:
+                inc_factor = self.get_inc_factor()
+                if inc_factor == conf.inc_factor:
+                    conf.inc_factor = int((conf.inc_factor + inc_factor) / 2)
+                    conf.inc_loops(conf.inc_factor)
+
+        res['comments_total'] = int(conf.comm_total / conf.get_mult_factor())
+        res['bundle'] = conf.final_items
+        return res
+
+
+class BundleConfig(object):
+    def __init__(self):
+        self.mult_factor = 20
+        self.comm_total = 0
+        self.work_list = []
+        self.loops = 0
+        self.load_mult = 600
+        self.inc_factor = 1
+        self.final_items = []
+
+    def get_mult_factor(self):
+        return self.mult_factor
+
+    def inc_loops(self, factor):
+        self.loops += factor
+
+    def list_extend(self, l):
+        self.work_list.extend(l)
+
+    def get_list(self):
+        return self.work_list

--- a/django-workload/django_workload/feed.py
+++ b/django-workload/django_workload/feed.py
@@ -10,6 +10,7 @@ import asyncio
 
 from .models import FeedEntryModel, UserModel
 from .users import suggested_users
+import json
 
 
 def wait_for(coro):
@@ -54,7 +55,71 @@ class Feed(object):
     def feed_page(self):
         self.prepare()
         self.run()
-        return self.context.endresult
+        result = self.post_process(self.context.endresult)
+        return result
+
+    def get_inc_factor(self):
+        result = int((1 + 1) / 2)
+        return result
+
+    def post_process(self, result):
+        item_list = result['items']
+        config = FeedConfig()
+
+        # remove suggestions from items list
+        items_len = len(item_list)
+        for i in range(items_len - 1, -1, -1):
+            if 'entry' not in item_list[i]:
+                config.sugg_list.append(item_list[i])
+                item_list.pop(i)
+
+        # duplicate the data
+        for i in range(config.get_mult_factor()):
+            config.list_extend(item_list)
+
+        # sort by comment count
+        s_list = sorted(config.work_list,
+                        key=lambda x: x['entry']['comment_count'],
+                        reverse=True)
+
+        # inefficiently bubble sort by time stamp decreasingly
+        while not config.is_sorted():
+            items_len = len(s_list)
+            config.swapped = False
+
+            for i in range(items_len - 1):
+                first = s_list[i]['entry']['published']
+                second = s_list[i + 1]['entry']['published']
+                if (first < second):
+                    aux = s_list[i]
+                    s_list[i] = s_list[i + 1]
+                    s_list[i + 1] = aux
+                    config.swapped = True
+
+            if not config.swapped:
+                config.set_sorted(True)
+
+        # un-duplicate the data
+        final_items = []
+        for item in s_list:
+            exists = False
+            for final_item in final_items:
+                if final_item['entry']['pk'] == item['entry']['pk']:
+                    exists = True
+                    break
+            if not exists:
+                final_items.append(item)
+            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL opcodes
+            config.loops = 0
+            load_mult = config.load_mult
+            while config.loops < load_mult:
+                inc_factor = self.get_inc_factor()
+                config.inc_loops(inc_factor)
+                inc_factor = inc_factor + inc_factor
+
+        result['items'] = final_items
+        result['items'].extend(config.sugg_list)
+        return result
 
     def prepare(self):
         self.context = context = Context(self.request)
@@ -108,6 +173,7 @@ class FollowedEntries(AsyncStep):
             }}
             for e in entries]
 
+
 class SuggestedUsers(AsyncStep):
     async def prepare(self):
         def fetch_users(userids):
@@ -128,9 +194,36 @@ class SuggestedUsers(AsyncStep):
                     for user in suggestions]
             })
 
+
 class Assemble(AsyncStep):
     def run(self):
         self.context.endresult = {
             'num_results': len(self.context.entries),
             'items': self.context.entries
         }
+
+
+class FeedConfig(object):
+    def __init__(self):
+        self.mult_factor = 10
+        self.sorted = False
+        self.load_mult = 700
+        self.loops = 0
+        self.work_list = []
+        self.sugg_list = []
+        self.swapped = False
+
+    def get_mult_factor(self):
+        return self.mult_factor
+
+    def is_sorted(self):
+        return self.sorted
+
+    def set_sorted(self, val):
+        self.sorted = val
+
+    def list_extend(self, l):
+        self.work_list.extend(l)
+
+    def inc_loops(self, factor):
+        self.loops += factor

--- a/django-workload/django_workload/feed.py
+++ b/django-workload/django_workload/feed.py
@@ -109,7 +109,7 @@ class Feed(object):
                     break
             if not exists:
                 final_items.append(item)
-            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL opcodes
+            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_FAST opcodes
             config.loops = 0
             load_mult = config.load_mult
             while config.loops < load_mult:

--- a/django-workload/django_workload/feed_timeline.py
+++ b/django-workload/django_workload/feed_timeline.py
@@ -1,0 +1,79 @@
+class FeedTimeline(object):
+    def __init__(self, request):
+        self.request = request
+
+    def get_timeline(self):
+            user = self.request.user
+            feed = user.feed_entries().limit(20)
+            user_info = user.json_data
+            result = {
+                'num_results': len(feed),
+                'items': [
+                    {
+                        'pk': str(e.id),
+                        'comment_count': e.comment_count,
+                        'published': e.published.timestamp(),
+                        'user': user_info
+                    }
+                    for e in feed]
+            }
+            return result
+
+    def get_inc_factor(self):
+        result = int((1 + 1) / 2)
+        return result
+
+    def post_process(self, result):
+        item_list = result['items']
+        conf = FeedTimelineConfig()
+
+        # duplicate the data
+        for i in range(conf.mult_factor):
+            conf.list_extend(item_list)
+
+        sorted_list = sorted(conf.get_list(),
+                             key=lambda x: x['published'],
+                             reverse=True)
+        final_items = []
+
+        for item in sorted_list:
+            conf.user = item['user']['name']
+            conf.comments_total = conf.comments_total + item['comment_count']
+            conf.comments_per_user[conf.user] = item['comment_count']
+            # un-duplicate the data
+            exists = False
+            for final_item in final_items:
+                if final_item['pk'] == item['pk']:
+                    exists = True
+                    break
+            if not exists:
+                final_items.append(item)
+            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL opcodes
+            conf.loops = 0
+            load_mult = conf.load_mult
+            while conf.loops < load_mult:
+                conf.inc_loops(self.get_inc_factor())
+
+        result['comments_total'] = int(conf.comments_total / conf.mult_factor)
+        result['items'] = final_items
+        return result
+
+
+class FeedTimelineConfig(object):
+    def __init__(self):
+        self.mult_factor = 5
+        self.work_list = []
+        self.user = ""
+        self.comments_total = 0
+        self.comments_per_user = {}
+        self.loops = 0
+        self.load_mult = 1000
+
+    def inc_loops(self, factor):
+        self.loops += factor
+
+    def list_extend(self, l):
+        self.work_list.extend(l)
+
+    def get_list(self):
+        return self.work_list

--- a/django-workload/django_workload/feed_timeline.py
+++ b/django-workload/django_workload/feed_timeline.py
@@ -48,7 +48,7 @@ class FeedTimeline(object):
                     break
             if not exists:
                 final_items.append(item)
-            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL opcodes
+            # boost LOAD_ATTR and CALL_FUNCTION opcodes
             conf.loops = 0
             load_mult = conf.load_mult
             while conf.loops < load_mult:

--- a/django-workload/django_workload/users.py
+++ b/django-workload/django_workload/users.py
@@ -14,6 +14,8 @@ from .models import UserModel
 
 # global cache; normally fetching users is cached in memcached or similar
 user_ids = None
+
+
 def all_users():
     global user_ids
     if user_ids is None:
@@ -28,7 +30,12 @@ def all_users():
 def require_user(view):
     @wraps(view)
     def wrapper(request, *args, **kwargs):
-        user_id = random.choice(all_users())
+        users = all_users()
+        user_id = users[0]
+        user_idx = random.randint(0, len(users))
+        for i in range(len(users)):
+            if i == user_idx:
+                user_id = users[user_idx]
         request.user = UserModel.objects.get(id=user_id)
         return view(request, *args, **kwargs)
     return wrapper


### PR DESCRIPTION
Added more Python work to each view to increase CPU utilization, as discussed. The code that was added just shuffles the data around and might look silly, but it produces a more realistic opcode distribution and I am able to see >95% CPU util (remote Cassandra setup).

The changes to the views are as follows:
- /feed_timeline: moved all the work from views.py to feed_timeline.py to boost LOAD_ATTR usage. The original data produced by the view is duplicated 5 times, sorted by publishing date, processed to obtain the total number of comments and finally un-duplicated. Also added a loop that does nothing but increase the number of times LOAD_ATTR and CALL_FUNCTION are used, to be more realistic.
- /timeline: added a post-processing step similar to the one described above. The original data is duplicated, sorted by comment count, bubble sorted again by publishing date, un-duplicated, after which a loop is added to stress LOAD_FAST, LOAD_ATTR and CALL_FUNCTION.
- /bundle_tray: moved all the work from views.py to bundle_tray.py. Again, added a post-processing step that duplicates the data, sorts it by publishing date, computes the total number of comments, un-duplicated the data and adds a loop that simply increases the number of times LOAD_ATTR, CALL_FUNCTION, POP_JUMP_IF_FALSE, LOAD_GLOBAL and LOAD_FAST are called.
- /inbox: added a post-processing step that again duplicates the data, computes the number of new likes, followers or other items using regular expressions, un-duplicates the data and adds a loop that increases the number of times LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL are used.

The way that a user ID in users.py was also changed to be more inefficient and use more Python cycles. Any feedback on these changes is appreciated.