### PR TITLE
Add Docker scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project aims to provide a Django workload based on a real-world
 large-scale production workload that serves mobile clients.
 
-## Setup
+## Setup for bare-metal
 
 The project can be set up on a single machine, or on a cluster of machines
 to spread the load and to make it easier to gauge the impact of the Django
@@ -14,16 +14,26 @@ each subdirectory. You'll need to follow the [README.md](/README.md) file in eac
 following locations:
 
 * 3 services
-  * Cassandra - services/cassandra
-  * Memcached - services/memcached
-  * Monitoring - services/monitoring
+  * Cassandra - [services/cassandra/README.md](/services/cassandra/README.md)
+  * Memcached - [services/memcached/README.md](/services/memcached/README.md)
+  * Monitoring - [services/monitoring/README.md](/services/monitoring/README.md)
 
-* Django and uWSGI - django-workload
-* A load generator - client
+* Django and uWSGI - [django-workload/README.md](/django-workload/README.md)
+* A load generator - [client/README.md](/client/README.md)
 
 Once set up, access http://[uwsgi_host:uwsgi_port]/ to see an overview of
 the offered endpoints, or use the load generator to produce a high request
 load on the server.
+
+## Setup for Docker containers
+
+The workload can also be deployed using Docker containers. The instructions can
+be found in [docker-scripts/README.md](/docker-scripts/README.md).
+
+Please note that running the workload using Docker containers might deliver
+less performance (transactions/second) than the bare-metal configuration and
+there might be more run-to-run variation. In order to obtain the most accurate
+performance comparison, please run the workload on bare-metal.
 
 ## Benchmarking configuration
 

--- a/docker-scripts/README.md
+++ b/docker-scripts/README.md
@@ -6,8 +6,20 @@ Workload. Each entity (Cassandra, uWSGI, Memcached, Siege, Graphite) is set up
 in a separate container.
 
 For instructions on how to install docker, please refer to:
+<https://docs.docker.com/engine/installation/linux/ubuntu/>
 
-    https://docs.docker.com/engine/installation/linux/ubuntu/
+## Warning
+
+The Cassandra heap size is set to 64GB in
+[docker-scripts/cassandra/jvm.options.128_GB](/docker-scripts/cassandra/jvm.options.128_GB).
+If your machine does not have that much RAM, starting the Cassandra container
+will cause swapping, therefore your machine will become unresponsive.
+
+Please change the value of the heap size in the file mentioned above to a more
+suitable value (change Xms and Xmx to half the system memory or less). Also
+change Xmn proportionally to the previous heap size (if changing heap size to
+1/4 its original value, also reduce Xmn to 1/4 its original value).
+
 
 ## Build the docker images
 
@@ -21,16 +33,32 @@ provide the script above with the absolute path to the install folder of your
 build
 
     # CPython tree
-    ./configure --prefix=/some/folder
+    ./configure --prefix=/python/install/folder
     make
     make install
     # Docker scripts
-    ./build_containers.sh /some/folder
+    ./build_containers.sh /python/install/folder
 
-If the UWSGI_ONLY environment variable is not set to 1, the above script will
-build all the containers. Since all other containers except uWSGI do not change
-between runs, UWSGI_ONLY=1 can be specified before the build_containers.sh
-script to only rebuild the Docker image for uWSGI:
+Please note that the latest Python version that was used to test the
+installation scripts was 3.6.3. Subsequent versions have not been tested. All
+the packages installed for Docker are the same as what would be installed on
+bare-metal if using Ubuntu 16.04. All Python dependencies installed via pip
+that do not have a specific version requirement are subject to change. At the
+time this documentation was written, the following package versions were used:
+* Cassandra 3.0.14
+* Memcached 1.4.25-2ubuntu1.2
+* Java 8u151
+* Siege 3.0.8
+* gcc 5.4.0-6ubuntu1
+* uWSGI 2.0.15
+
+The first time the workload is deployed, all images need to be built. After
+this, in order to measure the performance of a different Python build, only
+the uWSGI image needs to be re-built. This is the only image that changes, as
+the Python used for the workload changes.
+
+In order to build only the uWSGI image, UWSGI_ONLY=1 must be specified before
+the build_containers.sh script:
 
     # remember to remove the old container & image
     ./cleanup_containers.sh
@@ -42,8 +70,7 @@ to specify the "UWSGI_ONLY=1" variable __after__ the "sudo" word, otherwise it
 will not be taken into consideration.
 
 To run docker without "sudo", please follow the instructions here:
-
-    https://docs.docker.com/engine/installation/linux/linux-postinstall/
+<https://docs.docker.com/engine/installation/linux/linux-postinstall/>
 
 # Run the workload
 

--- a/docker-scripts/README.md
+++ b/docker-scripts/README.md
@@ -1,0 +1,60 @@
+# Docker containers setup files
+
+This directory contains all docker files and all necessary dependencies to
+build and deploy all the docker images necessary to run the Django
+Workload. Each entity (Cassandra, uWSGI, Memcached, Siege, Graphite) is set up
+in a separate container.
+
+For instructions on how to install docker, please refer to:
+
+    https://docs.docker.com/engine/installation/linux/ubuntu/
+
+## Build the docker images
+
+To build all the necessary images for the workload, run
+
+    [UWSGI_ONLY=1] ./build_containers.sh [/absolute/path/to/installed/python]
+
+Running the above script with no parameters will deploy the system Python 3.5.2
+on the uWSGI container. In order to deploy a custom Python build, please
+provide the script above with the absolute path to the install folder of your
+build
+
+    # CPython tree
+    ./configure --prefix=/some/folder
+    make
+    make install
+    # Docker scripts
+    ./build_containers.sh /some/folder
+
+If the UWSGI_ONLY environment variable is not set to 1, the above script will
+build all the containers. Since all other containers except uWSGI do not change
+between runs, UWSGI_ONLY=1 can be specified before the build_containers.sh
+script to only rebuild the Docker image for uWSGI:
+
+    # remember to remove the old container & image
+    ./cleanup_containers.sh
+    docker image rm uwsgi-webtier
+    UWSGI_ONLY=1 ./build_containers.sh /some/folder
+
+By default, docker commands will require root access. If using "sudo", remember
+to specify the "UWSGI_ONLY=1" variable __after__ the "sudo" word, otherwise it
+will not be taken into consideration.
+
+To run docker without "sudo", please follow the instructions here:
+
+    https://docs.docker.com/engine/installation/linux/linux-postinstall/
+
+# Run the workload
+
+Simply run:
+
+    # default number of Siege workers is 185. This can be
+    # changed using the WORKERS environment variable
+    [WORKERS=185] ./run_containers.sh
+
+# Cleanup containers
+
+In order to do another run, the previous containers need to be removed:
+
+    ./cleanup_containers.sh

--- a/docker-scripts/build_containers.sh
+++ b/docker-scripts/build_containers.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if [ "$1" == "--help" ]
+then
+    echo "Usage: [UWSGI_ONLY=1] ./build_containers [/absolute/path/to/cpython/install]"
+    exit 0
+fi
+
+
+# default Python build
+if [[ $# -lt 1 ]]
+then
+    cp uwsgi/Dockerfile.default uwsgi/Dockerfile
+    cd uwsgi/
+    docker build --no-cache -t uwsgi-webtier .
+    cd ../
+# custom Python build
+else
+    rm -rf uwsgi/cpython
+    cp -r $1 uwsgi/cpython
+    PLATFORM_TRIPLET=$(./get_platform_triplet.sh)
+    if [ $? -ne 0 ]; then exit $?; fi 
+    PYTHON_SOABI=$(./get_python_soabi.sh uwsgi/cpython/bin/python3)
+    if [ $? -ne 0 ]; then exit $?; fi 
+    PYTHON_VERSION=$(./get_python_version.sh uwsgi/cpython/bin/python3)
+    if [ $? -ne 0 ]; then exit $?; fi 
+    PYTHON_SHARED=$(./get_python_shared.sh uwsgi/cpython/bin/python3)
+    if [ $? -ne 0 ]; then exit $?; fi 
+    echo $PLATFORM_TRIPLET $PYTHON_SOABI $PYTHON_VERSION $PYTHON_SHARED
+
+    if [[ $PYTHON_SHARED == "1" ]]
+    then
+        cp uwsgi/Dockerfile.shared uwsgi/Dockerfile
+    else
+        cp uwsgi/Dockerfile.static uwsgi/Dockerfile
+    fi
+    cd uwsgi/
+    echo "Building image for uwsgi-webtier"
+    docker build --no-cache -t uwsgi-webtier                        \
+                 --build-arg cpython_install="cpython"              \
+                 --build-arg platform_triplet="$PLATFORM_TRIPLET"   \
+                 --build-arg python_soabi="$PYTHON_SOABI"           \
+                 --build-arg python_version="$PYTHON_VERSION" .
+    echo "-------------------------------------------------------------"
+    echo
+    cd ../
+fi
+
+if [[ "$UWSGI_ONLY" != "1" ]]
+then
+    DOCKER_LOCATIONS="cassandra graphite memcached siege"
+    for d in $DOCKER_LOCATIONS
+    do
+        cd "$d"
+        echo "Building image for $d-webtier"
+        docker build --no-cache -t "$d"-webtier .
+        echo "-------------------------------------------------------------"
+        echo
+        cd ../ 
+    done
+fi

--- a/docker-scripts/cassandra/Dockerfile
+++ b/docker-scripts/cassandra/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+RUN apt-get update                                                                     \
+    && mkdir /scripts                                                                  \
+    && apt-get install -y curl                                                         \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0xC2518248EEA14886 \
+    && curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -                 \
+    && echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main"         \
+        > /etc/apt/sources.list.d/webupd8team-ubuntu-java-xenial.list                  \
+    && echo "deb http://www.apache.org/dist/cassandra/debian 30x main"                 \
+        > /etc/apt/sources.list.d/cassandra.list                                       \
+    && echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true"   \
+        | debconf-set-selections                                                       \
+    && echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 seen true"     \
+        | debconf-set-selections                                                       \
+    && apt-get update                                                                  \
+    && apt-get install -y oracle-java8-installer cassandra
+
+COPY set_sysctl.conf init_config.sh /scripts/
+
+COPY jvm.options.128_GB /etc/cassandra/jvm.options
+
+RUN /scripts/init_config.sh cassandra
+
+RUN echo "Add nf_conntrack to modules ...\n"\
+    && echo "nf_conntrack" >> /etc/modules \
+    && echo "Add limits settings ...\n"\
+    && echo "* soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "* hard nofile 1000000" >> /etc/security/limits.conf
+
+RUN cp /scripts/set_sysctl.conf /etc/sysctl.conf
+
+ENV DEBIAN_FRONTEND teletype
+
+CMD service cassandra start \
+    && tail -f /dev/null

--- a/docker-scripts/cassandra/init_config.sh
+++ b/docker-scripts/cassandra/init_config.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script is called when the cassandra image is built
+# It receives the hostname as a parameter (cassandra)
+
+HOSTNAME=$1
+
+# Settings for 2-socket Broadwell-EP with 22 cores per socket,
+# all services running on same machine
+
+sed -e "s/listen_address: localhost/listen_address: $HOSTNAME/g"                               \
+    -e "s/seeds: \"127.0.0.1\"/seeds: \"$HOSTNAME\"/g"                                         \
+    -e "s/rpc_address: localhost/rpc_address: $HOSTNAME/g"                                     \
+    -e "s/concurrent_reads: 32/concurrent_reads: 64/g"                                         \
+    -e "s/concurrent_writes: 32/concurrent_writes: 128/g"                                      \
+    -e "s/concurrent_counter_writes: 32/concurrent_counter_writes: 128/g"                      \
+    -e "s/concurrent_materialized_view_writes: 32/# concurrent_materialized_view_writes: 32/g" \
+    -i /etc/cassandra/cassandra.yaml

--- a/docker-scripts/cassandra/jvm.options.128_GB
+++ b/docker-scripts/cassandra/jvm.options.128_GB
@@ -1,0 +1,56 @@
+-XX:+UseThreadPriorities
+-XX:ThreadPriorityPolicy=42
+
+# Heap size (Xms, Xmx) and young generation size (Xmn) should be set depending
+# on the amount of available memory. These settings work for a memory size of 128GB
+-Xms64G
+-Xmx64G
+-Xmn16G
+
+-XX:+HeapDumpOnOutOfMemoryError
+-Xss256k
+-XX:StringTableSize=1000003
+
+# CMS settings
+-XX:+UseParNewGC
+-XX:+UseConcMarkSweepGC
+-XX:+CMSParallelRemarkEnabled
+-XX:SurvivorRatio=4
+-XX:MaxTenuringThreshold=1
+-XX:CMSInitiatingOccupancyFraction=60
+-XX:+UseCMSInitiatingOccupancyOnly
+
+-XX:+CMSScavengeBeforeRemark
+-XX:CMSMaxAbortablePrecleanTime=60000
+
+-XX:CMSWaitDuration=30000
+-XX:+CMSParallelInitialMarkEnabled
+-XX:+CMSEdenChunksRecordAlways
+-XX:+CMSClassUnloadingEnabled
+
+# Additional settings
+-XX:+UseCondCardMark
+-XX:MaxTenuringThreshold=2
+-XX:-UseBiasedLocking
+-XX:+UseTLAB
+-XX:+ResizeTLAB
+-XX:+PerfDisableSharedMem
+-XX:+AlwaysPreTouch
+-XX:+UnlockDiagnosticVMOptions
+-XX:ParGCCardsPerStrideChunk=4096
+
+# If needed, logging can be enabled for Cassandra by uncommenting the following flags:
+
+############## Logging ###############
+# -XX:+PrintGCDetails
+# -XX:+PrintGCDateStamps
+# -XX:+PrintTenuringDistribution
+# -XX:+PrintGCApplicationStoppedTime
+# -XX:+PrintPromotionFailure
+# -XX:+PrintClassHistogramBeforeFullGC
+# -XX:+PrintClassHistogramAfterFullGC
+# -Xloggc:/var/log/cassandra/gc.log
+# -XX:+UseGCLogFileRotation
+# -XX:NumberOfGCLogFiles=2
+# -XX:GCLogFileSize=10M
+############## Logging ###############

--- a/docker-scripts/cassandra/set_sysctl.conf
+++ b/docker-scripts/cassandra/set_sysctl.conf
@@ -1,0 +1,20 @@
+net.ipv4.tcp_tw_reuse=1
+net.ipv4.tcp_tw_recycle=0
+net.ipv4.ip_local_port_range=1024 65535
+net.ipv4.tcp_fin_timeout=45
+net.core.netdev_max_backlog=10000
+net.ipv4.tcp_max_syn_backlog=12048
+net.core.somaxconn=16384
+net.netfilter.nf_conntrack_max = 512000
+net.ipv4.tcp_syncookies = 1
+#
+# cassandra suggested settings
+#
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.core.rmem_default = 16777216
+net.core.wmem_default = 16777216
+net.core.optmem_max = 40960
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 87380 16777216
+vm.max_map_count = 1048575

--- a/docker-scripts/cleanup_containers.sh
+++ b/docker-scripts/cleanup_containers.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+docker stop memcached_container
+docker rm memcached_container
+
+docker stop cassandra_container
+docker rm cassandra_container
+
+docker stop graphite_container
+docker rm graphite_container
+
+docker stop uwsgi_container
+docker rm uwsgi_container
+
+docker stop siege_container
+docker rm siege_container
+
+docker network rm django_network

--- a/docker-scripts/get_platform_triplet.sh
+++ b/docker-scripts/get_platform_triplet.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+cat >> conftest.c <<EOF
+#undef linux
+#undef i386
+#undef unix
+# if defined(__linux__)
+# if defined(__x86_64__) && defined(__LP64__)
+        x86_64-linux-gnu
+# elif defined(__x86_64__) && defined(__ILP32__)
+        x86_64-linux-gnux32
+# elif defined(__i386__)
+        i386-linux-gnu
+# elif defined(__ia64__)
+        ia64-linux-gnu
+# else
+#  error unknown platform triplet
+# endif
+#elif defined(__FreeBSD_kernel__)
+# if defined(__LP64__)
+        x86_64-kfreebsd-gnu
+# elif defined(__i386__)
+        i386-kfreebsd-gnu
+# else
+#   error unknown platform triplet
+# endif
+#elif defined(__gnu_hurd__)
+        i386-gnu
+#else
+# error unknown platform triplet
+#endif
+EOF
+
+gcc -E conftest.c >conftest.out 2>/dev/null
+grep -v '^#' conftest.out | grep -v '^ *$' | tr -d '    '
+rm -rf conftest.c conftest.out

--- a/docker-scripts/get_python_shared.sh
+++ b/docker-scripts/get_python_shared.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cat >> conftest.py <<EOF
+from distutils import sysconfig
+print(sysconfig.get_config_var('Py_ENABLE_SHARED'))
+
+EOF
+
+$1 conftest.py
+EXIT_CODE=$?
+rm -rf conftest.py
+exit $EXIT_CODE

--- a/docker-scripts/get_python_soabi.sh
+++ b/docker-scripts/get_python_soabi.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cat >> conftest.py <<EOF
+import sys
+print(sys.abiflags)
+
+EOF
+
+$1 conftest.py
+EXIT_CODE=$?
+rm -rf conftest.py
+exit $EXIT_CODE

--- a/docker-scripts/get_python_version.sh
+++ b/docker-scripts/get_python_version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cat >> conftest.py <<EOF
+from distutils import sysconfig
+print(sysconfig.get_config_var('VERSION'))
+
+EOF
+
+$1 conftest.py
+EXIT_CODE=$?
+rm -rf conftest.py
+exit $EXIT_CODE

--- a/docker-scripts/graphite/Dockerfile
+++ b/docker-scripts/graphite/Dockerfile
@@ -1,0 +1,9 @@
+FROM hopsoft/graphite-statsd
+
+ENV DEBIAN_FRONTEND noninteractive
+
+COPY storage-schemas.conf /opt/graphite/conf/storage-schemas.conf
+COPY blacklist.conf /opt/graphite/conf/blacklist.conf
+COPY carbon.conf /opt/graphite/conf/carbon.conf
+
+ENV DEBIAN_FRONTEND teletype

--- a/docker-scripts/graphite/blacklist.conf
+++ b/docker-scripts/graphite/blacklist.conf
@@ -1,0 +1,6 @@
+# This file takes a single regular expression per line
+# If USE_WHITELIST is set to True in carbon.conf, any metrics received which
+# match one of these expressions will be dropped
+# This file is reloaded automatically when changes are made
+^some\.noisy\.metric\.prefix\..*
+^stats[^.]*\.benchmarkoutput\.

--- a/docker-scripts/graphite/carbon.conf
+++ b/docker-scripts/graphite/carbon.conf
@@ -1,0 +1,359 @@
+[cache]
+# Configure carbon directories.
+#
+# OS environment variables can be used to tell carbon where graphite is
+# installed, where to read configuration from and where to write data.
+#
+#   GRAPHITE_ROOT        - Root directory of the graphite installation.
+#                          Defaults to ../
+#   GRAPHITE_CONF_DIR    - Configuration directory (where this file lives).
+#                          Defaults to $GRAPHITE_ROOT/conf/
+#   GRAPHITE_STORAGE_DIR - Storage directory for whipser/rrd/log/pid files.
+#                          Defaults to $GRAPHITE_ROOT/storage/
+#
+# To change other directory paths, add settings to this file. The following
+# configuration variables are available with these default values:
+#
+#   STORAGE_DIR    = $GRAPHITE_STORAGE_DIR
+#   LOCAL_DATA_DIR = STORAGE_DIR/whisper/
+#   WHITELISTS_DIR = STORAGE_DIR/lists/
+#   CONF_DIR       = STORAGE_DIR/conf/
+#   LOG_DIR        = STORAGE_DIR/log/
+#   PID_DIR        = STORAGE_DIR/
+#
+# For FHS style directory structures, use:
+#
+#   STORAGE_DIR    = /var/lib/carbon/
+#   CONF_DIR       = /etc/carbon/
+#   LOG_DIR        = /var/log/carbon/
+#   PID_DIR        = /var/run/
+#
+#LOCAL_DATA_DIR = /opt/graphite/storage/whisper/
+
+# Enable daily log rotation. If disabled, a kill -HUP can be used after a manual rotate
+ENABLE_LOGROTATION = True
+
+# Specify the user to drop privileges to
+# If this is blank carbon runs as the user that invokes it
+# This user must have write access to the local data directory
+USER =
+#
+# NOTE: The above settings must be set under [relay] and [aggregator]
+#       to take effect for those daemons as well
+
+# Limit the size of the cache to avoid swapping or becoming CPU bound.
+# Sorts and serving cache queries gets more expensive as the cache grows.
+# Use the value "inf" (infinity) for an unlimited cache size.
+MAX_CACHE_SIZE = inf
+
+# Limits the number of whisper update_many() calls per second, which effectively
+# means the number of write requests sent to the disk. This is intended to
+# prevent over-utilizing the disk and thus starving the rest of the system.
+# When the rate of required updates exceeds this, then carbon's caching will
+# take effect and increase the overall throughput accordingly.
+MAX_UPDATES_PER_SECOND = 500
+
+# If defined, this changes the MAX_UPDATES_PER_SECOND in Carbon when a
+# stop/shutdown is initiated.  This helps when MAX_UPDATES_PER_SECOND is
+# relatively low and carbon has cached a lot of updates; it enables the carbon
+# daemon to shutdown more quickly.
+# MAX_UPDATES_PER_SECOND_ON_SHUTDOWN = 1000
+
+# Softly limits the number of whisper files that get created each minute.
+# Setting this value low (like at 50) is a good way to ensure your graphite
+# system will not be adversely impacted when a bunch of new metrics are
+# sent to it. The trade off is that it will take much longer for those metrics'
+# database files to all get created and thus longer until the data becomes usable.
+# Setting this value high (like "inf" for infinity) will cause graphite to create
+# the files quickly but at the risk of slowing I/O down considerably for a while.
+MAX_CREATES_PER_MINUTE = 50
+
+LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_PORT = 2003
+
+# Set this to True to enable the UDP listener. By default this is off
+# because it is very common to run multiple carbon daemons and managing
+# another (rarely used) port for every carbon instance is not fun.
+ENABLE_UDP_LISTENER = False
+UDP_RECEIVER_INTERFACE = 0.0.0.0
+UDP_RECEIVER_PORT = 2003
+
+PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_PORT = 2004
+
+# Set to false to disable logging of successful connections
+LOG_LISTENER_CONNECTIONS = True
+
+# Per security concerns outlined in Bug #817247 the pickle receiver
+# will use a more secure and slightly less efficient unpickler.
+# Set this to True to revert to the old-fashioned insecure unpickler.
+USE_INSECURE_UNPICKLER = False
+
+CACHE_QUERY_INTERFACE = 0.0.0.0
+CACHE_QUERY_PORT = 7002
+
+# Set this to False to drop datapoints received after the cache
+# reaches MAX_CACHE_SIZE. If this is True (the default) then sockets
+# over which metrics are received will temporarily stop accepting
+# data until the cache size falls below 95% MAX_CACHE_SIZE.
+USE_FLOW_CONTROL = True
+
+# By default, carbon-cache will log every whisper update and cache hit. This can be excessive and
+# degrade performance if logging on the same volume as the whisper data is stored.
+LOG_UPDATES = False
+LOG_CACHE_HITS = False
+LOG_CACHE_QUEUE_SORTS = True
+
+# The thread that writes metrics to disk can use on of the following strategies
+# determining the order in which metrics are removed from cache and flushed to
+# disk. The default option preserves the same behavior as has been historically
+# available in version 0.9.10.
+#
+# sorted - All metrics in the cache will be counted and an ordered list of
+# them will be sorted according to the number of datapoints in the cache at the
+# moment of the list's creation. Metrics will then be flushed from the cache to
+# disk in that order.
+#
+# max - The writer thread will always pop and flush the metric from cache
+# that has the most datapoints. This will give a strong flush preference to
+# frequently updated metrics and will also reduce random file-io. Infrequently
+# updated metrics may only ever be persisted to disk at daemon shutdown if
+# there are a large number of metrics which receive very frequent updates OR if
+# disk i/o is very slow.
+#
+# naive - Metrics will be flushed from the cache to disk in an unordered
+# fashion. This strategy may be desirable in situations where the storage for
+# whisper files is solid state, CPU resources are very limited or deference to
+# the OS's i/o scheduler is expected to compensate for the random write
+# pattern.
+#
+CACHE_WRITE_STRATEGY = sorted
+
+# On some systems it is desirable for whisper to write synchronously.
+# Set this option to True if you'd like to try this. Basically it will
+# shift the onus of buffering writes from the kernel into carbon's cache.
+WHISPER_AUTOFLUSH = False
+
+# By default new Whisper files are created pre-allocated with the data region
+# filled with zeros to prevent fragmentation and speed up contiguous reads and
+# writes (which are common). Enabling this option will cause Whisper to create
+# the file sparsely instead. Enabling this option may allow a large increase of
+# MAX_CREATES_PER_MINUTE but may have longer term performance implications
+# depending on the underlying storage configuration.
+# WHISPER_SPARSE_CREATE = False
+
+# Only beneficial on linux filesystems that support the fallocate system call.
+# It maintains the benefits of contiguous reads/writes, but with a potentially
+# much faster creation speed, by allowing the kernel to handle the block
+# allocation and zero-ing. Enabling this option may allow a large increase of
+# MAX_CREATES_PER_MINUTE. If enabled on an OS or filesystem that is unsupported
+# this option will gracefully fallback to standard POSIX file access methods.
+WHISPER_FALLOCATE_CREATE = True
+
+# Enabling this option will cause Whisper to lock each Whisper file it writes
+# to with an exclusive lock (LOCK_EX, see: man 2 flock). This is useful when
+# multiple carbon-cache daemons are writing to the same files
+# WHISPER_LOCK_WRITES = False
+
+# Set this to True to enable whitelisting and blacklisting of metrics in
+# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
+# empty, all metrics will pass through
+USE_WHITELIST = True
+
+# By default, carbon itself will log statistics (such as a count,
+# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
+# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
+# CARBON_METRIC_PREFIX = carbon
+# CARBON_METRIC_INTERVAL = 60
+
+# Enable AMQP if you want to receve metrics using an amqp broker
+# ENABLE_AMQP = False
+
+# Verbose means a line will be logged for every metric received
+# useful for testing
+# AMQP_VERBOSE = False
+
+# AMQP_HOST = localhost
+# AMQP_PORT = 5672
+# AMQP_VHOST = /
+# AMQP_USER = guest
+# AMQP_PASSWORD = guest
+# AMQP_EXCHANGE = graphite
+# AMQP_METRIC_NAME_IN_BODY = False
+
+# The manhole interface allows you to SSH into the carbon daemon
+# and get a python interpreter. BE CAREFUL WITH THIS! If you do
+# something like time.sleep() in the interpreter, the whole process
+# will sleep! This is *extremely* helpful in debugging, assuming
+# you are familiar with the code. If you are not, please don't
+# mess with this, you are asking for trouble :)
+#
+# ENABLE_MANHOLE = False
+# MANHOLE_INTERFACE = 127.0.0.1
+# MANHOLE_PORT = 7222
+# MANHOLE_USER = admin
+# MANHOLE_PUBLIC_KEY = ssh-rsa AAAAB3NzaC1yc2EAAAABiwAaAIEAoxN0sv/e4eZCPpi3N3KYvyzRaBaMeS2RsOQ/cDuKv11dlNzVeiyc3RFmCv5Rjwn/lQ79y0zyHxw67qLyhQ/kDzINc4cY41ivuQXm2tPmgvexdrBv5nsfEpjs3gLZfJnyvlcVyWK/lId8WUvEWSWHTzsbtmXAF2raJMdgLTbQ8wE=
+
+# Patterns for all of the metrics this machine will store. Read more at
+# http://en.wikipedia.org/wiki/Advanced_Message_Queuing_Protocol#Bindings
+#
+# Example: store all sales, linux servers, and utilization metrics
+# BIND_PATTERNS = sales.#, servers.linux.#, #.utilization
+#
+# Example: store everything
+# BIND_PATTERNS = #
+
+# To configure special settings for the carbon-cache instance 'b', uncomment this:
+#[cache:b]
+#LINE_RECEIVER_PORT = 2103
+#PICKLE_RECEIVER_PORT = 2104
+#CACHE_QUERY_PORT = 7102
+# and any other settings you want to customize, defaults are inherited
+# from [carbon] section.
+# You can then specify the --instance=b option to manage this instance
+
+
+
+[relay]
+LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_PORT = 2013
+PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_PORT = 2014
+
+# Set to false to disable logging of successful connections
+LOG_LISTENER_CONNECTIONS = True
+
+# Carbon-relay has several options for metric routing controlled by RELAY_METHOD
+#
+# Use relay-rules.conf to route metrics to destinations based on pattern rules
+#RELAY_METHOD = rules
+#
+# Use consistent-hashing for even distribution of metrics between destinations
+#RELAY_METHOD = consistent-hashing
+#
+# Use consistent-hashing but take into account an aggregation-rules.conf shared
+# by downstream carbon-aggregator daemons. This will ensure that all metrics
+# that map to a given aggregation rule are sent to the same carbon-aggregator
+# instance.
+# Enable this for carbon-relays that send to a group of carbon-aggregators
+#RELAY_METHOD = aggregated-consistent-hashing
+RELAY_METHOD = rules
+
+# If you use consistent-hashing you can add redundancy by replicating every
+# datapoint to more than one machine.
+REPLICATION_FACTOR = 1
+
+# This is a list of carbon daemons we will send any relayed or
+# generated metrics to. The default provided would send to a single
+# carbon-cache instance on the default port. However if you
+# use multiple carbon-cache instances then it would look like this:
+#
+# DESTINATIONS = 127.0.0.1:2004:a, 127.0.0.1:2104:b
+#
+# The general form is IP:PORT:INSTANCE where the :INSTANCE part is
+# optional and refers to the "None" instance if omitted.
+#
+# Note that if the destinations are all carbon-caches then this should
+# exactly match the webapp's CARBONLINK_HOSTS setting in terms of
+# instances listed (order matters!).
+#
+# If using RELAY_METHOD = rules, all destinations used in relay-rules.conf
+# must be defined in this list
+DESTINATIONS = 127.0.0.1:2004
+
+# This defines the maximum "message size" between carbon daemons.
+# You shouldn't need to tune this unless you really know what you're doing.
+MAX_DATAPOINTS_PER_MESSAGE = 500
+MAX_QUEUE_SIZE = 10000
+
+# Set this to False to drop datapoints when any send queue (sending datapoints
+# to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
+# default) then sockets over which metrics are received will temporarily stop accepting
+# data until the send queues fall below 80% MAX_QUEUE_SIZE.
+USE_FLOW_CONTROL = True
+
+# Set this to True to enable whitelisting and blacklisting of metrics in
+# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
+# empty, all metrics will pass through
+# USE_WHITELIST = False
+
+# By default, carbon itself will log statistics (such as a count,
+# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
+# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
+# CARBON_METRIC_PREFIX = carbon
+# CARBON_METRIC_INTERVAL = 60
+
+
+[aggregator]
+LINE_RECEIVER_INTERFACE = 0.0.0.0
+LINE_RECEIVER_PORT = 2023
+
+PICKLE_RECEIVER_INTERFACE = 0.0.0.0
+PICKLE_RECEIVER_PORT = 2024
+
+# Set to false to disable logging of successful connections
+LOG_LISTENER_CONNECTIONS = True
+
+# If set true, metric received will be forwarded to DESTINATIONS in addition to
+# the output of the aggregation rules. If set false the carbon-aggregator will
+# only ever send the output of aggregation.
+FORWARD_ALL = True
+
+# This is a list of carbon daemons we will send any relayed or
+# generated metrics to. The default provided would send to a single
+# carbon-cache instance on the default port. However if you
+# use multiple carbon-cache instances then it would look like this:
+#
+# DESTINATIONS = 127.0.0.1:2004:a, 127.0.0.1:2104:b
+#
+# The format is comma-delimited IP:PORT:INSTANCE where the :INSTANCE part is
+# optional and refers to the "None" instance if omitted.
+#
+# Note that if the destinations are all carbon-caches then this should
+# exactly match the webapp's CARBONLINK_HOSTS setting in terms of
+# instances listed (order matters!).
+DESTINATIONS = 127.0.0.1:2004
+
+# If you want to add redundancy to your data by replicating every
+# datapoint to more than one machine, increase this.
+REPLICATION_FACTOR = 1
+
+# This is the maximum number of datapoints that can be queued up
+# for a single destination. Once this limit is hit, we will
+# stop accepting new data if USE_FLOW_CONTROL is True, otherwise
+# we will drop any subsequently received datapoints.
+MAX_QUEUE_SIZE = 10000
+
+# Set this to False to drop datapoints when any send queue (sending datapoints
+# to a downstream carbon daemon) hits MAX_QUEUE_SIZE. If this is True (the
+# default) then sockets over which metrics are received will temporarily stop accepting
+# data until the send queues fall below 80% MAX_QUEUE_SIZE.
+USE_FLOW_CONTROL = True
+
+# This defines the maximum "message size" between carbon daemons.
+# You shouldn't need to tune this unless you really know what you're doing.
+MAX_DATAPOINTS_PER_MESSAGE = 500
+
+# This defines how many datapoints the aggregator remembers for
+# each metric. Aggregation only happens for datapoints that fall in
+# the past MAX_AGGREGATION_INTERVALS * intervalSize seconds.
+MAX_AGGREGATION_INTERVALS = 5
+
+# By default (WRITE_BACK_FREQUENCY = 0), carbon-aggregator will write back
+# aggregated data points once every rule.frequency seconds, on a per-rule basis.
+# Set this (WRITE_BACK_FREQUENCY = N) to write back all aggregated data points
+# every N seconds, independent of rule frequency. This is useful, for example,
+# to be able to query partially aggregated metrics from carbon-cache without
+# having to first wait rule.frequency seconds.
+# WRITE_BACK_FREQUENCY = 0
+
+# Set this to True to enable whitelisting and blacklisting of metrics in
+# CONF_DIR/whitelist and CONF_DIR/blacklist. If the whitelist is missing or
+# empty, all metrics will pass through
+# USE_WHITELIST = False
+
+# By default, carbon itself will log statistics (such as a count,
+# metricsReceived) with the top level prefix of 'carbon' at an interval of 60
+# seconds. Set CARBON_METRIC_INTERVAL to 0 to disable instrumentation
+# CARBON_METRIC_PREFIX = carbon
+# CARBON_METRIC_INTERVAL = 60

--- a/docker-scripts/graphite/graphite_config.sh
+++ b/docker-scripts/graphite/graphite_config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is necessary to configure the statsd container in order
+# not to run out of disk space
+
+echo "Configuring statsd on container..."
+
+echo "^stats[^.]*\.benchmarkoutput\." >> /opt/graphite/conf/blacklist.conf
+echo "Configured benchmarkoutput"
+sed -i '/USE_WHITELIST/c\USE_WHITELIST = True' /opt/graphite/conf/carbon.conf
+echo "Configured whitelist"

--- a/docker-scripts/graphite/storage-schemas.conf
+++ b/docker-scripts/graphite/storage-schemas.conf
@@ -1,0 +1,17 @@
+# Schema definitions for Whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds.
+#
+#  [name]
+#  pattern = regex
+#  retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
+
+# Carbon's internal metrics. This entry should match what is specified in
+# CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
+
+[carbon]
+pattern = ^carbon\.
+retentions = 10s:6h,1min:90d
+
+[default_1min_for_1day]
+pattern = .*
+retentions = 10s:2h,1min:2d,10min:14d

--- a/docker-scripts/memcached/Dockerfile
+++ b/docker-scripts/memcached/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+# Update our apt index and create scripts directory
+RUN apt-get update
+RUN apt-get -y install memcached
+RUN mkdir scripts
+
+COPY memcached_init.sh set_sysctl.conf memcached.cfg /scripts/
+RUN echo "Add nf_conntrack to modules ...\n"\
+    && echo "nf_conntrack" >> /etc/modules \
+    && echo "Add limits settings ...\n"\
+    && echo "* soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "* hard nofile 1000000" >> /etc/security/limits.conf
+
+RUN cp /scripts/set_sysctl.conf /etc/sysctl.conf
+
+ENV DEBIAN_FRONTEND teletype
+
+CMD /scripts/memcached_init.sh

--- a/docker-scripts/memcached/memcached.cfg
+++ b/docker-scripts/memcached/memcached.cfg
@@ -1,0 +1,11 @@
+# 5 GB
+MEMORY="5120"
+
+# Network config
+LISTEN="0.0.0.0"
+PORT="11811"
+
+# User to run under
+USER="memcache"
+
+THREADS="16"

--- a/docker-scripts/memcached/memcached_init.sh
+++ b/docker-scripts/memcached/memcached_init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script will configure and start the memcached service inside a docker
+# container
+
+if [ -f /etc/memcached.conf ]; then
+    mv /etc/memcached.conf /etc/memcached.conf.old
+    echo -e "\n\nBackup /etc/memcached.conf to /etc/memcached.conf.old"
+fi
+
+. /scripts/memcached.cfg
+
+echo -e "\n\nWrite memcached config file ..."
+cat > /etc/memcached.conf <<- EOF
+	# Daemon mode
+	-d
+	logfile /var/log/memcached.log
+	-m "$MEMORY"
+	-p "$PORT"
+	-u "$USER"
+	-l "$LISTEN"
+	-t "$THREADS"
+EOF
+
+service memcached start  \
+    && tail -f /dev/null

--- a/docker-scripts/memcached/set_sysctl.conf
+++ b/docker-scripts/memcached/set_sysctl.conf
@@ -1,0 +1,20 @@
+net.ipv4.tcp_tw_reuse=1
+net.ipv4.tcp_tw_recycle=0
+net.ipv4.ip_local_port_range=1024 65535
+net.ipv4.tcp_fin_timeout=45
+net.core.netdev_max_backlog=10000
+net.ipv4.tcp_max_syn_backlog=12048
+net.core.somaxconn=16384
+net.netfilter.nf_conntrack_max = 512000
+net.ipv4.tcp_syncookies = 1
+#
+# cassandra suggested settings
+#
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.core.rmem_default = 16777216
+net.core.wmem_default = 16777216
+net.core.optmem_max = 40960
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 87380 16777216
+vm.max_map_count = 1048575

--- a/docker-scripts/run_containers.sh
+++ b/docker-scripts/run_containers.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# This function will wait until the specified port on the specified machine is available
+# Parameters: $1 = the IP; $2 = the port; $3 = the name of the service
+wait_port() {
+  while ! netcat -w 5 "$1" "$2"; do
+    echo "Waiting for $3 ..."
+    sleep 3
+  done
+}
+
+docker network create --opt com.docker.network.bridge.name=django --attachable \
+       -d bridge --gateway 10.10.10.1 --subnet 10.10.10.0/24                   \
+       --ip-range 10.10.10.8/29 django_network
+
+# Start memcached container
+echo "Staring memcached container"
+docker run -tid -h memcached --name memcached_container --network              \
+       django_network --ip 10.10.10.10 memcached-webtier
+
+wait_port 10.10.10.10 11811 memcached
+echo "Memcached is up and running!"
+
+# Start cassandra container
+echo "Starting cassandra container"
+docker run -tid --privileged -h cassandra --name cassandra_container           \
+           --network django_network --ip 10.10.10.11 cassandra-webtier
+
+wait_port 10.10.10.11 9042 cassandra
+echo "Cassandra is up and running!"
+
+# Start graphite container
+echo "Starting graphite container"
+docker run -tid -h graphite --name graphite_container --network django_network \
+           --ip 10.10.10.12 graphite-webtier
+
+wait_port 10.10.10.12 80 graphite
+echo "Graphite is up and running!"
+
+# Start uwsgi container
+echo "Starting uwsgi container"
+docker run -tid -h uwsgi --name uwsgi_container --network django_network        \
+           --ip 10.10.10.13 -e GRAPHITE_ENDPOINT=10.10.10.12                    \
+           -e CASSANDRA_ENDPOINT=10.10.10.11                                    \
+           -e MEMCACHED_ENDPOINT="10.10.10.10:11811"                            \
+           -e SIEGE_ENDPOINT=10.10.10.14 uwsgi-webtier
+
+wait_port 10.10.10.13 8000 uwsgi
+
+echo "uWSGI is up and running!"
+
+# Start siege container
+echo "Starting siege container"
+docker run -ti -h siege --name siege_container --volume=/tmp:/tmp --privileged \
+           --network django_network -e ATTEMPTS=10                             \
+           -e TARGET_ENDPOINT=10.10.10.13 -e SIEGE_WORKERS=${WORKERS:-185}     \
+           siege-webtier

--- a/docker-scripts/siege/Dockerfile
+++ b/docker-scripts/siege/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+RUN useradd -m tester
+RUN apt-get update
+RUN apt-get -y install git siege python3 python3-numpy netcat-openbsd
+RUN git clone https://github.com/Instagram/django-workload               \
+        /home/tester/django-workload                                     \
+    && cd /home/tester/django-workload/                                  \
+    && echo "failures = 1000000" > /home/tester/.siegerc                 \
+    && echo "protocol = HTTP/1.1" >> /home/tester/.siegerc               \
+    && mkdir -p /home/tester/scripts
+
+COPY siege_init.sh set_sysctl.conf /home/tester/scripts/
+
+RUN chown -R tester:tester /home/tester \
+    && echo "Add nf_conntrack to modules ...\n"\
+    && echo "nf_conntrack" >> /etc/modules \
+    && echo "Add limits settings ...\n"\
+    && echo "* soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "* hard nofile 1000000" >> /etc/security/limits.conf
+
+RUN cp /home/tester/scripts/set_sysctl.conf /etc/sysctl.conf
+
+ENV DEBIAN_FRONTEND teletype
+
+CMD /home/tester/scripts/siege_init.sh

--- a/docker-scripts/siege/set_sysctl.conf
+++ b/docker-scripts/siege/set_sysctl.conf
@@ -1,0 +1,20 @@
+net.ipv4.tcp_tw_reuse=1
+net.ipv4.tcp_tw_recycle=0
+net.ipv4.ip_local_port_range=1024 65535
+net.ipv4.tcp_fin_timeout=45
+net.core.netdev_max_backlog=10000
+net.ipv4.tcp_max_syn_backlog=12048
+net.core.somaxconn=16384
+net.netfilter.nf_conntrack_max = 512000
+net.ipv4.tcp_syncookies = 1
+#
+# cassandra suggested settings
+#
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.core.rmem_default = 16777216
+net.core.wmem_default = 16777216
+net.core.optmem_max = 40960
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 87380 16777216
+vm.max_map_count = 1048575

--- a/docker-scripts/siege/siege_init.sh
+++ b/docker-scripts/siege/siege_init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -rf /tmp/siege*
+chown -R tester:tester /tmp
+
+echo "Running with $SIEGE_WORKERS Siege workers"
+su - tester -c "cd django-workload/client                                  \
+                && sed -i 's/localhost/$TARGET_ENDPOINT/g' urls.txt        \
+                && LOG='/tmp/siege.log' WORKERS=$SIEGE_WORKERS ./run-siege"
+

--- a/docker-scripts/uwsgi/Dockerfile
+++ b/docker-scripts/uwsgi/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+RUN mkdir /scripts
+
+RUN apt-get update
+RUN apt-get install -y git python3-virtualenv python3-dev  \
+        python-pip libmemcached-dev zlib1g-dev netcat-openbsd
+RUN git clone https://github.com/Instagram/django-workload    \
+    && cd django-workload/django-workload                     \
+    && python3 -m virtualenv -p python3  venv                 \
+    && . venv/bin/activate                                    \
+    && pip install -r requirements.txt                        \
+    && deactivate                                             \
+    && cp cluster_settings_template.py cluster_settings.py
+
+COPY set_sysctl.conf uwsgi_init.sh /scripts/
+RUN echo "Add nf_conntrack to modules ...\n"\
+    && echo "nf_conntrack" >> /etc/modules \
+    && echo "Add limits settings ...\n"\
+    && echo "root soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "root hard nofile 1000000" >> /etc/security/limits.conf
+
+RUN cp /scripts/set_sysctl.conf /etc/sysctl.conf
+
+ENV DEBIAN_FRONTEND teletype
+
+CMD /scripts/uwsgi_init.sh uwsgi

--- a/docker-scripts/uwsgi/Dockerfile.default
+++ b/docker-scripts/uwsgi/Dockerfile.default
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+RUN mkdir /scripts
+
+RUN apt-get update
+RUN apt-get install -y git python3-virtualenv python3-dev  \
+        python-pip libmemcached-dev zlib1g-dev netcat-openbsd
+RUN git clone https://github.com/Instagram/django-workload    \
+    && cd django-workload/django-workload                     \
+    && python3 -m virtualenv -p python3  venv                 \
+    && . venv/bin/activate                                    \
+    && pip install -r requirements.txt                        \
+    && deactivate                                             \
+    && cp cluster_settings_template.py cluster_settings.py
+
+COPY set_sysctl.conf uwsgi_init.sh /scripts/
+RUN echo "Add nf_conntrack to modules ...\n"\
+    && echo "nf_conntrack" >> /etc/modules \
+    && echo "Add limits settings ...\n"\
+    && echo "root soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "root hard nofile 1000000" >> /etc/security/limits.conf
+
+RUN cp /scripts/set_sysctl.conf /etc/sysctl.conf
+
+ENV DEBIAN_FRONTEND teletype
+
+CMD /scripts/uwsgi_init.sh uwsgi

--- a/docker-scripts/uwsgi/Dockerfile.shared
+++ b/docker-scripts/uwsgi/Dockerfile.shared
@@ -1,0 +1,40 @@
+FROM ubuntu:16.04
+
+ARG cpython_install
+ARG python_soabi
+ARG platform_triplet
+ARG python_version
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+RUN mkdir /scripts && mkdir /cpython
+ADD $cpython_install /cpython
+RUN ln -s /cpython/lib/libpython"$python_version""$python_soabi".so /usr/lib/libpython"$python_version""$python_soabi".so
+
+ENV LD_PRELOAD=/cpython/lib/libpython"$python_version""$python_soabi".so
+
+RUN apt-get update
+RUN apt-get install -y git python3-virtualenv python3-dev  \
+        python-pip libmemcached-dev zlib1g-dev netcat-openbsd
+RUN git clone https://github.com/Instagram/django-workload    \
+    && cd django-workload/django-workload                     \
+    && python3 -m virtualenv -p /cpython/bin/python3  venv    \
+    && . venv/bin/activate                                    \
+    && pip install -r requirements.txt                        \
+    && deactivate                                             \
+    && cp cluster_settings_template.py cluster_settings.py
+
+COPY set_sysctl.conf uwsgi_init.sh /scripts/
+RUN echo "Add nf_conntrack to modules ...\n"\
+    && echo "nf_conntrack" >> /etc/modules \
+    && echo "Add limits settings ...\n"\
+    && echo "root soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "root hard nofile 1000000" >> /etc/security/limits.conf
+
+RUN cp /scripts/set_sysctl.conf /etc/sysctl.conf
+
+ENV DEBIAN_FRONTEND teletype
+
+CMD /scripts/uwsgi_init.sh uwsgi

--- a/docker-scripts/uwsgi/Dockerfile.static
+++ b/docker-scripts/uwsgi/Dockerfile.static
@@ -1,0 +1,39 @@
+FROM ubuntu:16.04
+
+ARG cpython_install
+ARG python_soabi
+ARG platform_triplet
+ARG python_version
+
+ENV DEBIAN_FRONTEND noninteractive
+#ENV http_proxy http://proxy-address:proxy-port
+#ENV https_proxy https://proxy-address:proxy-port
+
+RUN mkdir /scripts && mkdir /cpython
+ADD $cpython_install /cpython
+
+RUN apt-get update
+RUN apt-get install -y git python3-virtualenv python3-dev  \
+        python-pip libmemcached-dev zlib1g-dev netcat-openbsd
+RUN git clone https://github.com/Instagram/django-workload    \
+    && cd django-workload/django-workload                     \
+    && python3 -m virtualenv -p /cpython/bin/python3  venv    \
+    && ln -s config-"$python_version""$python_soabi"-"$platform_triplet" venv/lib/python"$python_version"/config-"$python_version""$python_soabi" \
+    && ln -s libpython"$python_version""$python_soabi".a venv/lib/python"$python_version"/config-"$python_version""$python_soabi"/libpython"$python_version".a \
+    && . venv/bin/activate                                    \
+    && pip install -r requirements.txt                        \
+    && deactivate                                             \
+    && cp cluster_settings_template.py cluster_settings.py
+
+COPY set_sysctl.conf uwsgi_init.sh /scripts/
+RUN echo "Add nf_conntrack to modules ...\n"\
+    && echo "nf_conntrack" >> /etc/modules \
+    && echo "Add limits settings ...\n"\
+    && echo "root soft nofile 1000000" >> /etc/security/limits.conf \
+    && echo "root hard nofile 1000000" >> /etc/security/limits.conf
+
+RUN cp /scripts/set_sysctl.conf /etc/sysctl.conf
+
+ENV DEBIAN_FRONTEND teletype
+
+CMD /scripts/uwsgi_init.sh uwsgi

--- a/docker-scripts/uwsgi/set_sysctl.conf
+++ b/docker-scripts/uwsgi/set_sysctl.conf
@@ -1,0 +1,20 @@
+net.ipv4.tcp_tw_reuse=1
+net.ipv4.tcp_tw_recycle=0
+net.ipv4.ip_local_port_range=1024 65535
+net.ipv4.tcp_fin_timeout=45
+net.core.netdev_max_backlog=10000
+net.ipv4.tcp_max_syn_backlog=12048
+net.core.somaxconn=16384
+net.netfilter.nf_conntrack_max = 512000
+net.ipv4.tcp_syncookies = 1
+#
+# cassandra suggested settings
+#
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.core.rmem_default = 16777216
+net.core.wmem_default = 16777216
+net.core.optmem_max = 40960
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 87380 16777216
+vm.max_map_count = 1048575

--- a/docker-scripts/uwsgi/uwsgi_init.sh
+++ b/docker-scripts/uwsgi/uwsgi_init.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script will be executed each time the uWSGI container is run.
+# It is called with a single parameter ($1) - the container hostname (uwsgi)
+
+echo "Starting uWSGI init script on container..."
+
+IP_ADDR=$(grep "$1" /etc/hosts | awk '{print $1}')
+
+cd /django-workload/django-workload || exit 1
+
+if [ -f cluster_settings.py.bak ]; then
+    cp -f cluster_settings.py.bak cluster_settings.py
+else
+    sed -e "s/DATABASES\['default'\]\['HOST'\] = 'localhost'/DATABASES\['default'\]\['HOST'\] = '$CASSANDRA_ENDPOINT'/g"                                  \
+        -e "s/CACHES\['default'\]\['LOCATION'\] = '127.0.0.1:11811'/CACHES\['default'\]\['LOCATION'\] = '$MEMCACHED_ENDPOINT'/g"                          \
+        -e "s/ALLOWED_HOSTS = \[/ALLOWED_HOSTS = \['$IP_ADDR', /g" \
+        -e "s/STATSD_HOST = 'localhost'/STATSD_HOST = '$GRAPHITE_ENDPOINT'/g"                                                                             \
+        -i cluster_settings.py
+
+    sed -i "s/processes = 88/processes = 100/g" uwsgi.ini # $(grep -c processor /proc/cpuinfo)/g" \
+
+    cp cluster_settings.py cluster_settings.py.bak
+fi
+
+. venv/bin/activate
+
+DJANGO_SETTINGS_MODULE=cluster_settings django-admin setup &> django-admin.log
+
+uwsgi uwsgi.ini &
+
+deactivate
+
+tail -f /dev/null

--- a/docker-scripts/uwsgi/uwsgi_init.sh
+++ b/docker-scripts/uwsgi/uwsgi_init.sh
@@ -18,7 +18,8 @@ else
         -e "s/STATSD_HOST = 'localhost'/STATSD_HOST = '$GRAPHITE_ENDPOINT'/g"                                                                             \
         -i cluster_settings.py
 
-    sed -i "s/processes = 88/processes = 100/g" uwsgi.ini # $(grep -c processor /proc/cpuinfo)/g" \
+    PROC_NO=$(grep -c processor /proc/cpuinfo)
+    sed -i "s/processes = 88/processes = $PROC_NO/g" uwsgi.ini
 
     cp cluster_settings.py cluster_settings.py.bak
 fi


### PR DESCRIPTION
Added Docker scripts that deploy every service (uWSGI, Cassandra, Memcached, Siege, Graphite) in its own container. In order to use the containers, the README.md file in the docker-scripts folder must be followed. On a high level, in order to run the containers, the following steps must be performed:
```
# build all the containers. The path to the Python install folder can be skipped, in which
# case the default Ubuntu Python 3.5.2 will be used
./build_containers.sh [/python/install/folder]

# run the containers with $WORKERS Siege workers. Not specifying this will use the
# default value of 185. The script will output the Siege summary at the end
[WORKERS=185] ./run_containers.sh
```