### PR TITLE
Remove CPU intensive loop

### DIFF
--- a/django-workload/django_workload/bundle_tray.py
+++ b/django-workload/django_workload/bundle_tray.py
@@ -5,9 +5,6 @@ from .models import (
 )
 
 
-INC_FACTOR = 1
-
-
 class BundleTray(object):
     def __init__(self, request):
         self.request = request
@@ -52,9 +49,6 @@ class BundleTray(object):
         ]}
         return result
 
-    def get_inc_factor(self):
-        return int((INC_FACTOR + 1 + 1) / 3)
-
     def dup_sort_data(self, bundle_list, conf):
         # duplicate the data
         for i in range(conf.get_mult_factor()):
@@ -85,15 +79,6 @@ class BundleTray(object):
                 conf.comm_total = conf.comm_total + sub['comment_count']
             # un-duplicate the data
             self.undup_data(item, conf)
-            # boost LOAD_ATTR, CALL_FUNCTION, POP_JUMP_IF_FALSE, LOAD_FAST
-            # and LOAD_GLOBAL opcodes
-            conf.loops = 0
-            load_mult = conf.load_mult
-            while conf.loops < load_mult:
-                inc_factor = self.get_inc_factor()
-                if inc_factor == conf.inc_factor:
-                    conf.inc_factor = int((conf.inc_factor + inc_factor) / 2)
-                    conf.inc_loops(conf.inc_factor)
 
         res['comments_total'] = int(conf.comm_total / conf.get_mult_factor())
         res['bundle'] = conf.final_items
@@ -107,18 +92,10 @@ class BundleConfig(object):
         self.mult_factor = 20
         self.comm_total = 0
         self.work_list = []
-        self.loops = 0
-        # Number of times the while loop in post_process is executed, in order
-        # to obtain a representative opcode usage for real-life scenarios
-        self.load_mult = 600
-        self.inc_factor = 1
         self.final_items = []
 
     def get_mult_factor(self):
         return self.mult_factor
-
-    def inc_loops(self, factor):
-        self.loops += factor
 
     def list_extend(self, l):
         self.work_list.extend(l)

--- a/django-workload/django_workload/feed.py
+++ b/django-workload/django_workload/feed.py
@@ -57,10 +57,6 @@ class Feed(object):
         result = self.post_process(self.context.endresult)
         return result
 
-    def get_inc_factor(self):
-        result = int((1 + 1) / 2)
-        return result
-
     def dup_data(self, item_list, config):
         # remove suggestions from items list
         items_len = len(item_list)
@@ -109,13 +105,6 @@ class Feed(object):
                     break
             if not exists:
                 final_items.append(item)
-            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_FAST opcodes
-            config.loops = 0
-            load_mult = config.load_mult
-            while config.loops < load_mult:
-                inc_factor = self.get_inc_factor()
-                config.inc_loops(inc_factor)
-                inc_factor = inc_factor + inc_factor
 
         result['items'] = final_items
         result['items'].extend(config.sugg_list)
@@ -209,10 +198,6 @@ class FeedConfig(object):
         # to make the view more Python intensive
         self.mult_factor = 10
         self.sorted = False
-        # Number of times the while loop in post_process is executed, in order
-        # to obtain a representative opcode usage for real-life scenarios
-        self.load_mult = 700
-        self.loops = 0
         self.work_list = []
         self.sugg_list = []
         self.swapped = False
@@ -228,6 +213,3 @@ class FeedConfig(object):
 
     def list_extend(self, l):
         self.work_list.extend(l)
-
-    def inc_loops(self, factor):
-        self.loops += factor

--- a/django-workload/django_workload/feed_timeline.py
+++ b/django-workload/django_workload/feed_timeline.py
@@ -19,10 +19,6 @@ class FeedTimeline(object):
             }
             return result
 
-    def get_inc_factor(self):
-        result = int((1 + 1) / 2)
-        return result
-
     def post_process(self, result):
         item_list = result['items']
         conf = FeedTimelineConfig()
@@ -48,11 +44,6 @@ class FeedTimeline(object):
                     break
             if not exists:
                 final_items.append(item)
-            # boost LOAD_ATTR and CALL_FUNCTION opcodes
-            conf.loops = 0
-            load_mult = conf.load_mult
-            while conf.loops < load_mult:
-                conf.inc_loops(self.get_inc_factor())
 
         result['comments_total'] = int(conf.comments_total / conf.mult_factor)
         result['items'] = final_items
@@ -68,13 +59,6 @@ class FeedTimelineConfig(object):
         self.user = ""
         self.comments_total = 0
         self.comments_per_user = {}
-        self.loops = 0
-        # Number of times the while loop in post_process is executed, in order
-        # to obtain a representative opcode usage for real-life scenarios
-        self.load_mult = 1000
-
-    def inc_loops(self, factor):
-        self.loops += factor
 
     def list_extend(self, l):
         self.work_list.extend(l)

--- a/django-workload/django_workload/inbox.py
+++ b/django-workload/django_workload/inbox.py
@@ -17,8 +17,6 @@ from .models import (
     UserModel,
 )
 
-INC_FACTOR = 1
-
 
 class AbstractAggregator(object):
     def add(self, entry):
@@ -179,11 +177,6 @@ class Inbox(object):
                     break
             if not exists:
                 final_items.append(item)
-            # boost LOAD_ATTR, CALL_FUNCTION and LOAD_GLOBAL opcodes
-            conf.loops = 0
-            load_mult = conf.load_mult
-            while conf.loops < load_mult:
-                conf.inc_loops(INC_FACTOR)
         return final_items
 
     def post_process(self, result):
@@ -208,9 +201,6 @@ class InboxConfig(object):
         # Number of times the original inbox items list is duplicated in order
         # to make the view more Python intensive
         self.mult_factor = 700
-        # Number of times the while loop in post_process is executed, in order
-        # to obtain a representative opcode usage for real-life scenarios
-        self.load_mult = 8
         self.work_list = []
         self.re_liked = '.* liked .*'
         self.re_followed = '.* following .*'
@@ -220,9 +210,6 @@ class InboxConfig(object):
         self.fresh_followers = 0
         self.other_items = 0
         self.loops = 0
-
-    def inc_loops(self, factor):
-        self.loops += factor
 
     def list_extend(self, l):
         self.work_list.extend(l)


### PR DESCRIPTION
Hello,

This PR removes the inner loop in the post_process function (in bundle_tray, inbox, feed and feed_timeline), introduced primarily to boost CPU utilization and the usage of LOAD_ATTR and other opcodes.

The reason is that 
•	Most of the workload instructions and cycles (about 77%) are spent in the removed loops, creating a hot spot that is not representative of production systems.
•	In the Instagram Blog, it is also reported that vast majority of loops are 4 iterations or less, But this particular hotspot loop is several million iterations.
•	This loop is a synthetic micro for exercising simple Python integer operations and is not beneficial to include in a general purpose Python workload.
