### PR TITLE
Change version requirement for django

### DIFF
--- a/django-workload/setup.py
+++ b/django-workload/setup.py
@@ -21,7 +21,7 @@ setup(
           'Development Status :: 3 - Alpha',
       ],
       install_requires=[
-          'Django >= 1.11',
+          'Django >= 1.11, < 2.0',
           'django-cassandra-engine',
           'django-statsd-mozilla',
           'psutil',


### PR DESCRIPTION
This fixes https://github.com/Instagram/django-workload/issues/35, solving the incompatibility between django and django_cassandra_engine.

